### PR TITLE
EstimateArrivalTimes RPC追加

### DIFF
--- a/stationapi.proto
+++ b/stationapi.proto
@@ -29,6 +29,8 @@ service StationAPI {
   rpc GetLinesByName(GetLinesByNameRequest) returns (MultipleLineResponse) {}
   rpc GetConnectedRoutes(GetConnectedStationsRequest) returns (RouteResponse) {}
   rpc GetRouteTypes(GetRouteRequest) returns (RouteTypeResponse) {}
+  rpc EstimateArrivalTimes(GetRouteRequest)
+      returns (EstimatedArrivalResponse) {}
 }
 
 message GetStationByIdRequest {
@@ -363,4 +365,21 @@ message RouteMinimalResponse {
   repeated RouteMinimal routes = 1;
   repeated LineMinimal lines = 2; // Normalized line data (deduplicated)
   string next_page_token = 3;
+}
+
+message EstimatedArrivalStop {
+  uint32 station_id = 1;
+  uint32 station_group_id = 2;
+  double cumulative_minutes = 3;
+  bool stops_here = 4;
+}
+
+message EstimatedArrivalRoute {
+  uint32 id = 1;
+  repeated EstimatedArrivalStop stops = 2;
+}
+
+message EstimatedArrivalResponse {
+  repeated EstimatedArrivalRoute routes = 1;
+  string next_page_token = 2;
 }


### PR DESCRIPTION
## Summary
- ルート到着時間推定を公開する専用RPC `EstimateArrivalTimes` を追加
- 新規メッセージ: `EstimatedArrivalStop`（各駅の累積分数・停車フラグ）、`EstimatedArrivalRoute`、`EstimatedArrivalResponse`
- 既存の `GetRouteRequest` を再利用し、ページネーション対応

Closes TrainLCD/StationAPI#1562

## Test plan
- [ ] StationAPI側で submodule pointer を更新し、`EstimateArrivalTimes` エンドポイントの結線を実装
- [ ] grpcurl 等で RPC を呼び出し、累積分数と停車フラグが正しく返ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)