### PR TITLE
GetTrainRoute RPC追加: A→B走行シミュレーション用クエリ

### DIFF
--- a/stationapi.proto
+++ b/stationapi.proto
@@ -31,6 +31,7 @@ service StationAPI {
   rpc GetRouteTypes(GetRouteRequest) returns (RouteTypeResponse) {}
   rpc EstimateArrivalTimes(GetRouteRequest)
       returns (EstimatedArrivalResponse) {}
+  rpc GetTrainRoute(GetTrainRouteRequest) returns (TrainRouteResponse) {}
 }
 
 message GetStationByIdRequest {
@@ -382,4 +383,23 @@ message EstimatedArrivalRoute {
 message EstimatedArrivalResponse {
   repeated EstimatedArrivalRoute routes = 1;
   string next_page_token = 2;
+}
+
+message GetTrainRouteRequest {
+  uint32 from_station_group_id = 1;
+  uint32 to_station_group_id = 2;
+  optional uint32 line_group_id = 3;
+}
+
+message TrainRouteSegment {
+  Station station = 1;
+  bool stops = 2;
+  double distance_from_previous = 3;
+  double max_speed = 4;
+  double max_acceleration = 5;
+  double max_deceleration = 6;
+}
+
+message TrainRouteResponse {
+  repeated TrainRouteSegment segments = 1;
 }

--- a/stationapi.proto
+++ b/stationapi.proto
@@ -392,11 +392,17 @@ message GetTrainRouteRequest {
 }
 
 message TrainRouteSegment {
+  // 既存 Station。緯度経度・stop_condition・train_type・line(line_type) を含む。
   Station station = 1;
+  // この駅に停車するか。通過駅(stop_condition == Not)は false。
   bool stops = 2;
+  // 直前駅からの距離 (メートル, Haversine)。先頭セグメントは 0。
   double distance_from_previous = 3;
+  // この駅へ向かう区間の最高巡航速度 (m/s)。正値。
   double max_speed = 4;
+  // 最大加速度 (m/s^2)。正値。
   double max_acceleration = 5;
+  // 最大減速度 (m/s^2)。正値（絶対値として格納）。
   double max_deceleration = 6;
 }
 


### PR DESCRIPTION
## Summary
- A→B間の走行シミュレーションに必要なメタ情報を1回のリクエストで取得する `GetTrainRoute` RPCを新設
- `GetTrainRouteRequest`: `from_station_group_id`, `to_station_group_id`, `line_group_id`(optional)を指定
- `TrainRouteSegment`: 既存`Station`を内包し、停車/通過(`stops`)、前駅からの距離(`distance_from_previous`)、速度プロファイル(`max_speed`, `max_acceleration`, `max_deceleration`)を付与
- `line_group_id`は列車種別が未設定の路線にも対応できるよう`optional`に設定

Closes https://github.com/TrainLCD/StationAPI/issues/1564

## Test plan
- [ ] StationAPI側で`GetTrainRoute`ハンドラを実装後、`grpcurl`で疎通確認
- [ ] 通過駅が`stops=false`、停車駅が`stops=true`で返ることを検証
- [ ] `line_group_id`省略時のフォールバック動作を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 列車ルートを取得する新しいAPIが追加されました。
  * 出発駅・到着駅に加え、任意で系統条件を指定してルートを取得できます。
  * ルート結果として、各区間の駅情報、停車有無、区間距離、速度・加減速に関する情報を返せるようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->