### PR TITLE
EstimateArrivalTimesの入力をstation_idに変更しvia_line_idsを配列化

### DIFF
--- a/stationapi.proto
+++ b/stationapi.proto
@@ -29,7 +29,7 @@ service StationAPI {
   rpc GetLinesByName(GetLinesByNameRequest) returns (MultipleLineResponse) {}
   rpc GetConnectedRoutes(GetConnectedStationsRequest) returns (RouteResponse) {}
   rpc GetRouteTypes(GetRouteRequest) returns (RouteTypeResponse) {}
-  rpc EstimateArrivalTimes(GetRouteRequest)
+  rpc EstimateArrivalTimes(EstimateArrivalTimesRequest)
       returns (EstimatedArrivalResponse) {}
   rpc GetTrainRoute(GetTrainRouteRequest) returns (TrainRouteResponse) {}
 }
@@ -81,6 +81,12 @@ message GetRouteRequest {
   uint32 page_size = 3;
   string page_token = 4;
   optional uint32 via_line_id = 5;
+}
+
+message EstimateArrivalTimesRequest {
+  uint32 from_station_id = 1;
+  uint32 to_station_id = 2;
+  repeated uint32 via_line_ids = 3;
 }
 
 message GetStationsByLineGroupIdRequest {


### PR DESCRIPTION
## 概要

`EstimateArrivalTimes` RPC の入力を `GetRouteRequest`（`station_group_id` ベース）から専用の `EstimateArrivalTimesRequest`（`station_id` ベース）に変更し、`via_line_id` を `repeated via_line_ids` に配列化。

## 変更の種類

- [ ] バグ修正
- [x] 新機能
- [ ] データの修正・追加
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `EstimateArrivalTimesRequest` メッセージを新設（`from_station_id`, `to_station_id`, `repeated via_line_ids`）
- `EstimateArrivalTimes` RPC のリクエスト型を `GetRouteRequest` → `EstimateArrivalTimesRequest` に変更
- 実用上、両端の駅IDがわからないままクエリを投げるケースが無いため `station_group_id` → `station_id` に変更
- 直通運転対応のため `via_line_id` を配列（`repeated`）に変更

## テスト

- [ ] `cargo fmt --all -- --check` が通ること
- [ ] `cargo clippy -- -D warnings` が通ること
- [ ] `cargo test`（`SQLX_OFFLINE=true`）が通ること

省略: Proto定義のみの変更でコードの変更なし

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UIやレスポンスに関する変更の場合、スクリーンショットを添付してください -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 到着予測のリクエスト形式が更新され、出発駅・到着駅・経由路線IDを指定して取得できるようになりました。
* **変更**
  * 到着予測APIの入力仕様が、より専用的なリクエストに切り替わりました。
  * 返却される予測結果の形式はそのままです。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->