### PR TITLE
EstimateArrivalTimesRequestにdirection_idフィールドを追加

### DIFF
--- a/stationapi.proto
+++ b/stationapi.proto
@@ -87,7 +87,7 @@ message EstimateArrivalTimesRequest {
   uint32 from_station_id = 1;
   uint32 to_station_id = 2;
   repeated uint32 via_line_ids = 3;
-  optional uint32 direction_id = 4; // Direction: 0 = default order, 1 or 2 = reverse order
+  optional uint32 direction_id = 4; // Direction: 0 = default order, 1 = reverse order
 }
 
 message GetStationsByLineGroupIdRequest {

--- a/stationapi.proto
+++ b/stationapi.proto
@@ -87,6 +87,7 @@ message EstimateArrivalTimesRequest {
   uint32 from_station_id = 1;
   uint32 to_station_id = 2;
   repeated uint32 via_line_ids = 3;
+  optional uint32 direction_id = 4; // Direction: 0 = default order, 1 or 2 = reverse order
 }
 
 message GetStationsByLineGroupIdRequest {


### PR DESCRIPTION
## Summary
- `EstimateArrivalTimesRequest` に `optional uint32 direction_id = 4` を追加
- 進行方向の指定により、駅の並び順を制御可能に（0 = デフォルト順、1 = 逆順）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ag6fgiLJj5ExLa9bqnfAhj
