### PR TITLE
EstimatedArrivalStopにdeparture_cumulative_minutes追加

### DIFF
--- a/stationapi.proto
+++ b/stationapi.proto
@@ -380,6 +380,10 @@ message EstimatedArrivalStop {
   uint32 station_group_id = 2;
   double cumulative_minutes = 3;
   bool stops_here = 4;
+  // 始点からの累積出発時刻(分)。中間停車駅では「到着 + 停車時間」、通過駅では
+  // 通過時刻(= cumulative_minutes)、終点では到着時刻と同じ。クライアントは
+  // 「到着(k) − 出発(基準駅)」で基準駅発の残り時間(発車基準 ETA)を計算できる。
+  double departure_cumulative_minutes = 5;
 }
 
 message EstimatedArrivalRoute {


### PR DESCRIPTION
## Summary
- `EstimatedArrivalStop`メッセージに `departure_cumulative_minutes` フィールド(field 5)を追加
- 中間停車駅では「到着 + 停車時間」、通過駅では通過時刻、終点では到着時刻と同値
- クライアント側で「到着(k) − 出発(基準駅)」を計算することで、発車基準のETAを算出できるようにする

## Test plan
- [ ] proto定義の構文チェック(既存のlint/生成ツールでの確認)
- [ ] 既存クライアントでフィールド追加による後方互換性の確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)