### PR TITLE
GetTrainRouteRequestのフィールドをstation_group_idからstation_idに変更

### DIFF
--- a/stationapi.proto
+++ b/stationapi.proto
@@ -397,8 +397,8 @@ message EstimatedArrivalResponse {
 }
 
 message GetTrainRouteRequest {
-  uint32 from_station_group_id = 1;
-  uint32 to_station_group_id = 2;
+  uint32 from_station_id = 1;
+  uint32 to_station_id = 2;
   optional uint32 line_group_id = 3;
 }
 


### PR DESCRIPTION
## Summary
- `GetTrainRouteRequest`の`from_station_group_id`/`to_station_group_id`を`from_station_id`/`to_station_id`にリネーム

## Test plan
- [ ] protoの生成コードに影響がないか確認